### PR TITLE
Fix datadir

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -22,7 +22,7 @@ LimitNPROC=64
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 PrivateTmp=yes
 PrivateDevices=yes
-ProtectHome=true
+ProtectHome=false
 ProtectSystem=strict
 
 [Install]

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,8 +8,8 @@ After=network.target
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/live/
-ReadWriteDirectories=__FINALPATH__/live/
-EnvironmentFile=__FINALPATH__/live/vaultwarden.env
+ReadWriteDirectories=__FINALPATH__/live/ __DATADIR__
+EnvironmentFile=__FINALPATH__/live/.env
 ExecStart=__FINALPATH__/live/vaultwarden
 
 # Set reasonable connection and process limits

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -114,7 +114,7 @@ fi
 #=================================================
 ynh_script_progression --message="Modifying a config file..."
 
-config="$final_path/live/vaultwarden.env"
+config="$final_path/live/.env"
 
 ynh_backup_if_checksum_is_different --file="$config"
 

--- a/scripts/install
+++ b/scripts/install
@@ -156,10 +156,10 @@ chown -R $app:$app "$datadir"
 #=================================================
 ynh_script_progression --message="Adding a configuration file..."
 
-ynh_add_config --template="../conf/vaultwarden.env" --destination="$final_path/live/vaultwarden.env"
+ynh_add_config --template="../conf/vaultwarden.env" --destination="$final_path/live/.env"
 
-chmod 400 "$final_path/live/vaultwarden.env"
-chown $app:$app "$final_path/live/vaultwarden.env"
+chmod 400 "$final_path/live/vaulwarden.env"
+chown $app:$app "$final_path/live/.env"
 
 #=================================================
 # SETUP SYSTEMD

--- a/scripts/install
+++ b/scripts/install
@@ -158,7 +158,7 @@ ynh_script_progression --message="Adding a configuration file..."
 
 ynh_add_config --template="../conf/vaultwarden.env" --destination="$final_path/live/.env"
 
-chmod 400 "$final_path/live/vaulwarden.env"
+chmod 400 "$final_path/live/.env"
 chown $app:$app "$final_path/live/.env"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -72,9 +72,9 @@ then
 	db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 
 	# Move config file
-	mv $final_path/live/bitwarden_rs.env $final_path/live/vaultwarden.env
+	mv $final_path/live/bitwarden_rs.env $final_path/live/.env
 	ynh_delete_file_checksum --file="/var/www/$old_app/live/bitwarden_rs.env"
-	ynh_store_file_checksum --file="$final_path/live/vaultwarden.env" 
+	ynh_store_file_checksum --file="$final_path/live/.env" 
 	ynh_secure_remove --file="$final_path/live/bitwarden_rs"
 
 	# Manage permissions
@@ -214,10 +214,10 @@ fi
 #=================================================
 ynh_script_progression --message="Updating a configuration file..."
 
-ynh_add_config --template="../conf/vaultwarden.env" --destination="$final_path/live/vaultwarden.env"
+ynh_add_config --template="../conf/vaultwarden.env" --destination="$final_path/live/.env"
 
-chmod 400 "$final_path/live/vaultwarden.env"
-chown $app:$app "$final_path/live/vaultwarden.env"
+chmod 400 "$final_path/live/.env"
+chown $app:$app "$final_path/live/.env"
 
 #=================================================
 # SETUP SYSTEMD


### PR DESCRIPTION
## Problem

- Fix #164 
- Vaultwarden can't write to `DATADIR` 
- can't find `.env` even if specified in the systemd unit.

## Solution

- Add `DATADIR` in `ReadWriteDirectories`
- Rename `vaultwarden.env` to `.env`. We don't delete `vaultwarden.env` in case someone had some custom values.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
