### PR TITLE
[fix] Create datadir after user is created

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,18 +91,6 @@ fi
 
 ynh_remove_logrotate
 
-# If datadir doesn't exist, create it
-if [ -z $datadir ]; then
-	datadir=/home/yunohost.app/$app
-	ynh_app_setting_set --app=$app --key=datadir --value=$datadir
-	mkdir -p $datadir
-	rsync -arz "$final_path/live/data/" "$datadir/" --delete-after --remove-source-files
-	ynh_secure_remove --file="$final_path/live/data"
-	chmod 750 "$datadir"
-	chmod -R o-rwx "$datadir"
-	chown -R $app:$app "$datadir"
-fi
-
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
@@ -132,6 +120,23 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 
 # Create a dedicated user (if not existing)
 ynh_system_user_create --username=$app --home_dir=$final_path
+
+#=================================================
+# CREATE DATA DIRECTORY
+#=================================================
+ynh_script_progression --message="Making sure data directory exists..."
+
+# If datadir doesn't exist, create it
+if [ -z $datadir ]; then
+	datadir=/home/yunohost.app/$app
+	ynh_app_setting_set --app=$app --key=datadir --value=$datadir
+	mkdir -p $datadir
+	rsync -arz "$final_path/live/data/" "$datadir/" --delete-after --remove-source-files
+	ynh_secure_remove --file="$final_path/live/data"
+	chmod 750 "$datadir"
+	chmod -R o-rwx "$datadir"
+	chown -R $app:$app "$datadir"
+fi
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
## Problem

- During upgrade, on migration from bitwarden, user `vaultwarden` does not exist when we set permission for the datadir
```
2022-01-24 13:45:18,612: DEBUG - + chown -R vaultwarden:vaultwarden /home/yunohost.app/vaultwarden
2022-01-24 13:45:18,616: WARNING - chown: invalid user: ‘vaultwarden:vaultwarden’
```
Fix #166

## Solution

- Create datadir after user is created

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
