### PR TITLE
Fix API permission for clients

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -211,7 +211,7 @@ then
 	ynh_permission_update --permission="main" --add="visitors"
 fi
 
-ynh_permission_create --permission="api" --url="/api" --additional_urls="/identity/connect/token" --allowed="visitors" --auth_header="false" --show_tile="false" --protected="true"
+ynh_permission_create --permission="api" --url="/api" --additional_urls="/identity" --allowed="visitors" --auth_header="false" --show_tile="false" --protected="true"
 ynh_permission_create --permission="admin" --url="/admin" --allowed="$admin" --show_tile="false"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -109,7 +109,9 @@ fi
 
 # Create a permission if needed
 if ! ynh_permission_exists --permission="api"; then
-	ynh_permission_create --permission="api" --url="/api" --additional_urls="/identity/connect/token" --allowed="visitors" --auth_header="false" --show_tile="false" --protected="true"
+	ynh_permission_create --permission="api" --url="/api" --additional_urls="/identity" --allowed="visitors" --auth_header="false" --show_tile="false" --protected="true"
+else
+	ynh_permission_url --permission="api" --remove_url="/identity/connect/token" --add_url="/identity"
 fi
 
 # If datadir doesn't exist, create it


### PR DESCRIPTION
I discovered that my Vaultwarden desktop client could not connect anymore. Changing the URL of the API from `/identity/connect/token` to only `/identity` fixed that.

We need to check if we don't expose sensitive endpoints doing that.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
