### PR TITLE
Fail2ban: check failed attemps in the admin panel too

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -61,7 +61,7 @@ chown -R $app:$app "/var/log/$app"
 ynh_use_logrotate
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="(^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$)|(^.*Invalid admin token\. IP: <ADDR>.*$)"
+ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$|^.*Invalid admin token\. IP: <ADDR>.*$"
 
 yunohost service add $app --description="$app daemon for vaultwarden" --log="/var/log/$app/$app.log"
 

--- a/scripts/install
+++ b/scripts/install
@@ -61,7 +61,7 @@ chown -R $app:$app "/var/log/$app"
 ynh_use_logrotate
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$"
+ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="(^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$)|(^.*Invalid admin token\. IP: <ADDR>.*$)"
 
 yunohost service add $app --description="$app daemon for vaultwarden" --log="/var/log/$app/$app.log"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -66,7 +66,7 @@ chown -R $app:$app "/var/log/$app"
 ynh_use_logrotate --non-append
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="(^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$)|(^.*Invalid admin token\. IP: <ADDR>.*$)"
+ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$|^.*Invalid admin token\. IP: <ADDR>.*$"
 
 yunohost service add $app --description="$app daemon for vaultwarden" --log="/var/log/$app/$app.log"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -66,7 +66,7 @@ chown -R $app:$app "/var/log/$app"
 ynh_use_logrotate --non-append
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$"
+ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="(^.*Username or password is incorrect\. Try again\. IP: <ADDR>\. Username:.*$)|(^.*Invalid admin token\. IP: <ADDR>.*$)"
 
 yunohost service add $app --description="$app daemon for vaultwarden" --log="/var/log/$app/$app.log"
 


### PR DESCRIPTION
## Problem

- fail2ban is configured for the user interface only, not the admin panel

## Solution

- [check failed attempts in the admin panel too](https://github.com/YunoHost-Apps/vaultwarden_ynh/commit/cbd7dfee71f0adeb79c293476618f17ef63f2c68)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
