### PR TITLE
Enable installation/upgrade on Yunohost version 11

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vaultwarden"
 description.en = "Manage passwords and other sensitive informations"
 description.fr = "Gérez les mots de passe et autres informations sensibles"
 
-version = "1.32.0~ynh1"
+version = "1.32.1~ynh1"
 
 maintainers = [ ]
 
@@ -19,7 +19,7 @@ userdoc = "https://help.bitwarden.com/"
 code = "https://github.com/dani-garcia/vaultwarden"
 
 [integration]
-yunohost = ">= 12.0.0"
+yunohost = ">= 11.2.20"
 architectures = "all"
 multi_instance = true
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -20,7 +20,7 @@ code = "https://github.com/dani-garcia/vaultwarden"
 
 [integration]
 yunohost = ">= 11.2.20"
-architectures = "all"
+architectures = ["amd64", "armhf", "arm64"]
 multi_instance = true
 
 ldap = false

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,12 +9,13 @@
 #=================================================
 
 _download_vaultwarden_from_docker() {
-    docker_image="vaultwarden/server"
     debian=$(lsb_release --codename --short)
     if [[ $debian = "bullseye" ]]; then
+        docker_image="p4p4j0hn/vaultwarden_ynh"
         docker_version="$(ynh_app_upstream_version)"
     elif [[ $debian = "bookworm" ]]; then
-        docker_version="$(ynh_app_upstream_version)-alpine"
+        docker_image="vaultwarden/server"
+        docker_version="$(ynh_app_upstream_version)"
     fi
 
     docker_arg=""

--- a/tests.toml
+++ b/tests.toml
@@ -12,4 +12,4 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.8899759a3264b9200920cf5f546fc519297b78ac.name = "Upgrade from 1.28.1~ynh1"
+    test_upgrade_from.a22247020feb9d80df35a3d527fff215680fc343.name = "Upgrade from 1.29.1~ynh4"


### PR DESCRIPTION
## Problem

Unable to install/upgrade Vaultwarden on YunoHost version 11. The upstream docker image is built on Debian bookworm so the libraries on bullseye are out of date. Also, there aren't i386 builds.

## Solution

I set up a GitHub Action container build based on Debian bullseye and updated the `_common.sh` script. Repo for that is https://github.com/p4p4j0hn/vaultwarden

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
