### PR TITLE
Added instructions to generate+use Argon2 PHC string (closes #290)

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -14,7 +14,7 @@ The linked instructions provide a detailed explanation about what it is and why 
 1. Enter Vaultwarden’s app shell with `sudo yunohost app shell vaultwarden`.
 1. Instead of just running `vaultwarden`, as the upstream documentation indicates, you can run the command by writing its whole path: `/var/www/vaultwarden/live/vaultwarden`. Therefore, e.g. to generate an Argon2id PHC string, run `/var/www/vaultwarden/live/vaultwarden hash`.
 1. Securely store both the password you entered and the generated Argon2 PHC string.
-1. Visit <https://your.vaultwarden.app/admin> using the original plain text Admin token provided after the installation, and paste the generated Argon2 PHC string in “General settings” > “Admin token/Argon2 PHC”.
-1. Change	the value of `admin_token` in `/etc/yunohost/apps/vaultwarden/settings.yml` with the generated Argon2 PHC string. **Note**: enclose the Argon2 PHC string in single or double quotes!
+1. Visit <https://__DOMAIN____PATH__/admin> using the original plain text Admin token provided after the installation, and paste the generated Argon2 PHC string in “General settings” > “Admin token/Argon2 PHC”.
+1. Change the value of `admin_token` in `__DATA_DIR__/settings.yml` with the generated Argon2 PHC string. **Note**: enclose the Argon2 PHC string in single or double quotes!
 1. Restart Vaultwarden, either from the YunoHost Admin interface, or by running `sudo yunohost service restart vaultwarden`.
-1. Visit <https://your.vaultwarden.app/admin>, and access it by entering **the password you chose while generating the Argon2 PHC string**.
+1. Visit <https://__DOMAIN____PATH__/admin>, and access it by entering **the password you chose when you generated the Argon2 PHC string**.


### PR DESCRIPTION
## Problem

It was not clear how to generate a secure Argon2 PHC string to access the admin page.

## Solution

Provided instructions to generate a secure Argon2 PHC string and enable it as the authentication method.

## PR Status

- [x] Code finished and ready to be reviewed/tested

## Note

This PR closes #290.