### PR TITLE
corrigé le lien pour accéder à l'interface admin

### DIFF
--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,4 +1,4 @@
-L'interface d'administration est accessible à <https://__DOMAIN____PATH__admin>
+L'interface d'administration est accessible à <https://__DOMAIN____PATH__/admin>
 
 Le jeton d'administration est : `__ADMIN_TOKEN__`
 


### PR DESCRIPTION
## Problem

Jusqu'à maintenant le message post-install proposait: https://lenomdudomaine.tld/vaultwardenadmin par exemple.

## Solution

en ajoutant un "/" le problème est résolu

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
