### PR TITLE
Use vaultwarden 1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Encrypted end-to-end password manager
 
-[![Version: 1.36.0~ynh1](https://img.shields.io/badge/Version-1.36.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/vaultwarden/)
+[![Version: 1.37.0~ynh1](https://img.shields.io/badge/Version-1.37.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/vaultwarden/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/vaultwarden"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vaultwarden"
 description.en = "Encrypted end-to-end password manager"
 description.fr = "Gestionnaire de mots de passe chiffré de bout en bout"
 
-version = "1.36.0~ynh1"
+version = "1.37.0~ynh1"
 
 maintainers = [ ]
 
@@ -55,12 +55,12 @@ ram.runtime = "70M"
     [resources.sources.main]
     #https://github.com/czyt/vaultwarden-binary/
     in_subdir = false
-    amd64.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.36.0-extracted/vaultwarden-linux-amd64-extracted.zip"
-    amd64.sha256 = "8a53ecd0e1123f6296b4113405e82edb4016e52689b7fd612577d6fab7d6e652"
-    arm64.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.36.0-extracted/vaultwarden-linux-arm64-extracted.zip"
-    arm64.sha256 = "aef42fd9e53a1e537046b5100df273adb045fd6b4e960781a93a4b83e8ca9ceb"
-    armhf.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.36.0-extracted/vaultwarden-linux-armv7-extracted.zip"
-    armhf.sha256 = "206c11062f1346acca378d5b44a9b5cf1fcda15936b27428ba0bf3a1e24cfdcf"
+    amd64.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.37.0-extracted/vaultwarden-linux-amd64-extracted.zip"
+    amd64.sha256 = "c126c9b3a47322fc2c34f34cd03cdb0d8205d0e90cae93fd8a84e4178b2a5356"
+    arm64.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.37.0-extracted/vaultwarden-linux-arm64-extracted.zip"
+    arm64.sha256 = "81e84f5ed7c05236651d1e1be479b5ad32d599a9c83c154429aec485774b72aa"
+    armhf.url = "https://github.com/czyt/vaultwarden-binary/releases/download/1.37.0-extracted/vaultwarden-linux-armv7-extracted.zip"
+    armhf.sha256 = "05a2dd92f2f4f9384909bcf4458335f843229fab3c85b0db762002158d4cfc28"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.upstream = "https://github.com/czyt/vaultwarden-binary"


### PR DESCRIPTION
## Problem
- There is a new vaultwarden version fixing the app for new clients

## Solution
- By updating the app

## PR Status
- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests
Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
